### PR TITLE
Parse show notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /.build
 /Packages
+Masse.xcodeproj

--- a/Sources/Masse/ConfigEntryParser.swift
+++ b/Sources/Masse/ConfigEntryParser.swift
@@ -20,11 +20,10 @@ struct ConfigEntryParser {
     func retrieve() -> [String: String] {
         var hasReachedSeparator = false
         var result: [String: String] = [:]
-        var notesLines = ""
+        var noteLines: [String] = []
         for line in contents.components(separatedBy: .newlines) {
-            if hasReachedSeperator {
-                notesLines.append("\(line)\n")
             if hasReachedSeparator {
+                noteLines.append(line)
             } else {
                 for key in keys {
                     let start = "\(metaPrefix)\(key)\(metaSeparator)"
@@ -38,7 +37,59 @@ struct ConfigEntryParser {
                 }
             }
         }
-        overflowKey.map { result[$0] = notesLines }
+        overflowKey.map { result[$0] = parsedNotes(noteLines).reduce("") { $0 + "\($1)\n" } }
+        return result
+    }
+
+    func parsedNotes(_ noteLines: [String]) -> [String] {
+        let titleKey = "# "
+        let entryKey = "- "
+        let entrySeparator = ": "
+        var result = ["<div>"]
+
+        func listEntry(forLine line: String) -> String {
+            guard let urlStart = line.range(of: entrySeparator)?.upperBound else { fatalError() }
+            let url = String(line[urlStart..<line.endIndex])
+            let name = line.between(beginString: metaPrefix, endString: "\(entrySeparator)\(url)")!
+            return "<li><a href=\"\(url)\">\(name)</a></li>"
+        }
+
+        func title(forLine line: String) -> String {
+            precondition(line.starts(with: titleKey))
+            return "<h3>\(line.dropFirst(2))</h3>"
+        }
+
+        var wasPreviousLineTopic = false
+        var wasPreviousLineEntry = false
+
+        noteLines.forEach {
+            if $0.starts(with: entryKey) { // li entry
+                if wasPreviousLineTopic == false && wasPreviousLineEntry == false {
+                    result.append("    <ul>")
+                }
+                result.append("      \(listEntry(forLine: $0))")
+                wasPreviousLineEntry = true
+            } else if wasPreviousLineEntry {
+                result.append("    </ul>")
+                wasPreviousLineEntry = false
+            }
+            if $0.starts(with: titleKey) {
+                if let lastLine = result.last, lastLine.isEmpty, let popped = result.popLast() {
+                    result.append("  </p>")
+                    result.append(popped)
+                }
+                result.append("  <p>")
+                result.append("    \(title(forLine: $0))")
+                result.append("    <ul>")
+                wasPreviousLineTopic = true
+            } else {
+                wasPreviousLineTopic = false
+            }
+            if $0.isEmpty { result.append("") }
+        }
+        result.append("    </ul>")
+        result.append("  </p>")
+        result.append("</div>")
         return result
     }
 }

--- a/Sources/Masse/ConfigEntryParser.swift
+++ b/Sources/Masse/ConfigEntryParser.swift
@@ -1,7 +1,7 @@
 struct ConfigEntryParser {
     private let metaPrefix = "- "
-    private let metaSeperator = ": "
-    private let seperator = "---"
+    private let metaSeparator = ": "
+    private let separator = "---"
     private let contents: String
     private let keys: [String]
     private let overflowKey: String?
@@ -18,22 +18,23 @@ struct ConfigEntryParser {
     }
     
     func retrieve() -> [String: String] {
-        var hasReachedSeperator = false
+        var hasReachedSeparator = false
         var result: [String: String] = [:]
         var notesLines = ""
         for line in contents.components(separatedBy: .newlines) {
             if hasReachedSeperator {
                 notesLines.append("\(line)\n")
+            if hasReachedSeparator {
             } else {
                 for key in keys {
-                    let start = "\(metaPrefix)\(key)\(metaSeperator)"
+                    let start = "\(metaPrefix)\(key)\(metaSeparator)"
                     if line.starts(with: start),
-                        let range = line.range(of: metaSeperator) {
+                        let range = line.range(of: metaSeparator) {
                         result[key] = String(line[range.upperBound..<line.endIndex])
                     }
                 }
-                if line == seperator && overflowKey != nil {
-                    hasReachedSeperator = true
+                if line == separator && overflowKey != nil {
+                    hasReachedSeparator = true
                 }
             }
         }

--- a/Sources/Masse/Keys.swift
+++ b/Sources/Masse/Keys.swift
@@ -4,7 +4,7 @@ enum Keys {
 
     }
     enum PodcastEntry: String, CaseIterable {
-                       case nr, title, date, file, duration, length, author, description, notes
+        case nr, title, date, file, duration, length, author, description, notes
     }
 }
 

--- a/Sources/Masse/MiniMarkdownParser.swift
+++ b/Sources/Masse/MiniMarkdownParser.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+/// Split into lines by `\n` however keep empty lines as empty strings
+internal func splitWithBreaks(lines: String) -> [Substring] {
+    var results: [Substring] = []
+    var (startIndex, currentIndex) = (lines.startIndex, lines.startIndex)
+    while currentIndex < lines.endIndex {
+        if lines[currentIndex] == "\n" {
+            let transformedIndex = startIndex
+            results.append(lines[transformedIndex..<currentIndex])
+            startIndex = lines.index(after: currentIndex)
+        }
+        currentIndex = lines.index(after: currentIndex)
+    }
+
+    if startIndex < lines.endIndex {
+        results.append(lines[startIndex..<lines.endIndex])
+    }
+    return results
+}
+
+internal struct MiniMarkdownParser {
+    internal enum Element {
+        case list(entries: [(index: Int, contents: Substring)])
+        case paragraph(contents: [Substring])
+        case headline(level: Int, title: Substring)
+        case footnote(identifier: Substring, contents: Substring)
+
+        internal var html: String {
+            var buffer = ""
+            switch self {
+            case .list(entries: let entries):
+                buffer.append("<ul>")
+                entries.forEach { entry in
+                    buffer.append("<li>\(convertRefs(entry.contents))</li>")
+                }
+                buffer.append("</ul>")
+            case .paragraph(contents: let contents):
+                buffer.append("<p>")
+                buffer.append(contents.map { convertRefs($0) }.joined(separator: "<br/>"))
+                buffer.append("</p>")
+            case .headline(level: let level, title: let title):
+                buffer.append("<h\(level)>\(convertRefs(title))</h\(level)>")
+            case .footnote(identifier: let identifier, contents: let contents):
+                buffer.append("<div><strong><a name='\(identifier)'>[\(identifier)]:</a></strong> \(contents)</div>")
+            }
+            return buffer
+        }
+
+        internal func convertRefs(_ input: Substring) -> String {
+            enum RefType { case image, link }
+            var buffer = ""
+            var refType = RefType.link
+            var currentIndex = input.startIndex
+            while let (textStartIndex, content) = findNext(in: input, character: "[", from: currentIndex) {
+
+                if textStartIndex > input.startIndex && input[input.index(before: textStartIndex)] == "!" {
+                    refType = .image
+                    buffer.append(String(content.dropLast()))
+                } else {
+                    buffer.append(String(content))
+                }
+
+                let next = input.index(after: textStartIndex)
+                if input[next] == "^" {
+                    guard let (index, text) = findNext(in: input, character: "]", from: input.index(after: next)) else { continue }
+                    buffer.append("<a href='#\(text)'>[\(text)]</a>")
+                    currentIndex = input.index(after: index)
+                    continue
+                }
+
+                guard let (textEndIndex, text) = findNext(in: input, character: "]", from: input.index(after: textStartIndex))
+                    else {
+                        currentIndex = input.index(after: textStartIndex)
+                        continue
+                }
+
+                guard let (urlStartIndex, _) = findNext(in: input, character: "(", from: textEndIndex)
+                    else {
+                        currentIndex = input.index(after: textEndIndex)
+                        continue
+
+                }
+
+                guard let (urlEndIndex, url) = findNext(in: input, character: ")", from: input.index(after: urlStartIndex))
+                    else {
+                        currentIndex = input.index(after: urlStartIndex)
+                        continue
+                }
+
+                currentIndex = input.index(after: urlEndIndex)
+
+                switch refType {
+                case .link: buffer.append("<a href='\(url)'>\(text)</a>")
+                case .image: buffer.append("<img src='\(url)' alt='\(text)' />")
+                }
+            }
+
+            if currentIndex < input.endIndex {
+                buffer.append(String(input[currentIndex..<input.endIndex]))
+            }
+            return buffer
+        }
+
+        func findNext(in string: Substring, character: Character, from: String.Index) -> (String.Index, Substring)? {
+            let substring = string[from..<string.endIndex]
+            guard let index = substring.firstIndex(of: character) else { return nil }
+            return (index, substring[substring.startIndex..<index])
+        }
+    }
+
+    /// The simplest possible markdown parser
+    /// Limitations:
+    /// - Headlines, lists, paragraphs, images, links, and footnotes
+    /// - Only Unix newlines supported
+    /// - Only '###' headlines are supported
+    /// - Only "- " lists are supported
+    /// - Only one space between '#' and content is supported (i.e. '## hello world' not '##    hello')
+    func parse(_ markdown: String) -> [Element] {
+        var elements: [Element] = []
+        var lineCollector: [Substring] = []
+        enum CurrenMode { case list, paragraph }
+        var currentMode = CurrenMode.paragraph
+        func processCollector() {
+            guard !lineCollector.isEmpty else { return }
+            switch currentMode {
+            case .list:
+                elements.append(.list(entries: lineCollector.enumerated().map { $0 }))
+            case .paragraph:
+                elements.append(.paragraph(contents: lineCollector))
+            }
+            lineCollector = []
+        }
+        for line in splitWithBreaks(lines: markdown) {
+            let headlineIndex = line.firstIndex(where: { $0 != "#" }) ?? line.startIndex
+            let headlineLevel = headlineIndex.encodedOffset - line.startIndex.encodedOffset
+            let isList = line.starts(with: "- ")
+            let isFootnote = line.starts(with: "[^")
+            let isParagraphEnd = line.isEmpty
+            if isParagraphEnd {
+                processCollector()
+            } else if headlineLevel > 0 {
+                elements.append(.headline(level: headlineLevel,
+                                          title: line[line.index(after: headlineIndex)..<line.endIndex]))
+            } else if isFootnote {
+                let identifier = line.dropFirst(2).prefix(while: { $0 != "]" })
+                let contents = line.drop(while: { $0 != "]" }).drop(while: { $0 != " " }).dropFirst()
+                elements.append(.footnote(identifier: identifier, contents: contents))
+            } else if isList {
+                if currentMode == .paragraph { processCollector() }
+                lineCollector.append(line.dropFirst(2))
+                currentMode = .list
+            } else {
+                if currentMode == .list { processCollector() }
+                lineCollector.append(line)
+                currentMode = .paragraph
+            }
+        }
+        processCollector()
+        return elements
+    }
+
+    func parseHTML(_ markdown: String) -> String {
+        return parse(markdown).map {$0.html}.joined()
+    }
+}

--- a/Sources/Masse/MiniMarkdownParser.swift
+++ b/Sources/Masse/MiniMarkdownParser.swift
@@ -1,24 +1,5 @@
 import Foundation
 
-/// Split into lines by `\n` however keep empty lines as empty strings
-internal func splitWithBreaks(lines: String) -> [Substring] {
-    var results: [Substring] = []
-    var (startIndex, currentIndex) = (lines.startIndex, lines.startIndex)
-    while currentIndex < lines.endIndex {
-        if lines[currentIndex] == "\n" {
-            let transformedIndex = startIndex
-            results.append(lines[transformedIndex..<currentIndex])
-            startIndex = lines.index(after: currentIndex)
-        }
-        currentIndex = lines.index(after: currentIndex)
-    }
-
-    if startIndex < lines.endIndex {
-        results.append(lines[startIndex..<lines.endIndex])
-    }
-    return results
-}
-
 internal struct MiniMarkdownParser {
     internal enum Element {
         case list(entries: [(index: Int, contents: Substring)])
@@ -131,7 +112,7 @@ internal struct MiniMarkdownParser {
             }
             lineCollector = []
         }
-        for line in splitWithBreaks(lines: markdown) {
+        for line in markdown.splitWithBreaks() {
             let headlineIndex = line.firstIndex(where: { $0 != "#" }) ?? line.startIndex
             let headlineLevel = headlineIndex.encodedOffset - line.startIndex.encodedOffset
             let isList = line.starts(with: "- ")

--- a/Sources/Masse/MiniMarkdownParser.swift
+++ b/Sources/Masse/MiniMarkdownParser.swift
@@ -140,9 +140,9 @@ internal struct MiniMarkdownParser {
             }
             lineCollector = []
         }
-        for line in markdown.splitWithBreaks() {
+        for line in markdown.split(separator: "\n", omittingEmptySubsequences: false) {
             let headlineIndex = line.firstIndex(where: { $0 != "#" }) ?? line.startIndex
-            let headlineLevel = headlineIndex.encodedOffset - line.startIndex.encodedOffset
+            let headlineLevel = headlineIndex.utf16Offset(in: line) - line.startIndex.utf16Offset(in: line)
             let isList = line.starts(with: "- ")
             let isFootnote = line.starts(with: "[^")
             let isParagraphEnd = line.isEmpty

--- a/Sources/Masse/String+Parsing.swift
+++ b/Sources/Masse/String+Parsing.swift
@@ -15,4 +15,23 @@ extension String {
         let endIndex = self.index(self.startIndex, offsetBy: endPosition)
         return String(self[beginIndex..<endIndex])
     }
+
+    /// Split into lines by `\n` however keep empty lines as empty strings
+    func splitWithBreaks() -> [Substring] {
+        var results: [Substring] = []
+        var (lowerIndex, upperIndex) = (startIndex, startIndex)
+        while upperIndex < endIndex {
+            if self[upperIndex] == "\n" {
+                let transformedIndex = lowerIndex
+                results.append(self[transformedIndex..<upperIndex])
+                lowerIndex = self.index(after: upperIndex)
+            }
+            upperIndex = index(after: upperIndex)
+        }
+
+        if lowerIndex < endIndex {
+            results.append(self[lowerIndex..<endIndex])
+        }
+        return results
+    }
 }

--- a/Sources/Masse/String+Parsing.swift
+++ b/Sources/Masse/String+Parsing.swift
@@ -5,33 +5,8 @@ extension String {
         guard self.starts(with: beginString) && self.suffix(endString.count) == endString else {
             return nil
         }
-        let beginPosition = self.index(self.startIndex, offsetBy: beginString.count).encodedOffset
-        let endPosition = self.index(self.endIndex, offsetBy: -endString.count).encodedOffset
-        return between(beginPosition: beginPosition, endPosition: endPosition)
-    }
-
-    func between(beginPosition: Int, endPosition: Int) -> String {
-        let beginIndex = self.index(self.startIndex, offsetBy: beginPosition)
-        let endIndex = self.index(self.startIndex, offsetBy: endPosition)
-        return String(self[beginIndex..<endIndex])
-    }
-
-    /// Split into lines by `\n` however keep empty lines as empty strings
-    func splitWithBreaks() -> [Substring] {
-        var results: [Substring] = []
-        var (lowerIndex, upperIndex) = (startIndex, startIndex)
-        while upperIndex < endIndex {
-            if self[upperIndex] == "\n" {
-                let transformedIndex = lowerIndex
-                results.append(self[transformedIndex..<upperIndex])
-                lowerIndex = self.index(after: upperIndex)
-            }
-            upperIndex = index(after: upperIndex)
-        }
-
-        if lowerIndex < endIndex {
-            results.append(self[lowerIndex..<endIndex])
-        }
-        return results
+        let beginPosition = self.index(self.startIndex, offsetBy: beginString.count)
+        let endPosition = self.index(self.endIndex, offsetBy: -endString.count)
+        return String(self[beginPosition..<endPosition])
     }
 }

--- a/Tests/MasseTests/MasseTests.swift
+++ b/Tests/MasseTests/MasseTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 @testable import Masse
 
+import Foundation
+
 final class MasseTests: XCTestCase {
     func testArguments() {
         XCTAssertEqual(arguments(for: ["a", "b", "--", "c"]), ["c"])

--- a/Tests/MasseTests/MiniMarkdownTests.swift
+++ b/Tests/MasseTests/MiniMarkdownTests.swift
@@ -85,18 +85,6 @@ final class MinimarkdownTests: XCTestCase {
         )
     }
 
-    func testSplitWithBreaks() {
-        let content = "a\n\nb\nc\nd\n\ne"
-        let parsed = content.splitWithBreaks()
-        XCTAssertEqual(parsed, ["a", "", "b", "c", "d", "", "e"])
-    }
-
-    func testSplitWithBreaksNoBreaks() {
-        let content = "# test"
-        let parsed = content.splitWithBreaks()
-        XCTAssertEqual(parsed, ["# test"])
-    }
-
     func testMarkdownTitle1() {
         XCTAssertEqual(convertMarkdown("# test"), "<h1>test</h1>")
     }
@@ -187,13 +175,14 @@ longer pargraph
         ("testHTMLRefs7", testHTMLRefs7),
         ("testHTMLRefs8", testHTMLRefs8),
         ("testHTMLRefs9", testHTMLRefs9),
-        ("testSplitWithBreaks", testSplitWithBreaks),
-        ("testSplitWithBreaksNoBreaks", testSplitWithBreaksNoBreaks),
         ("testMarkdownTitle1", testMarkdownTitle1),
         ("testMarkdownTitle2", testMarkdownTitle2),
         ("testMarkdownList", testMarkdownList),
         ("testMarkdownParagraphs1", testMarkdownParagraphs1),
         ("testMarkdownParagraphs2", testMarkdownParagraphs2),
         ("testEm1", testEm1),
+        ("testEm2", testEm2),
+        ("testEm3", testEm3),
+        ("testEm4", testEm4),
         ]
 }

--- a/Tests/MasseTests/MiniMarkdownTests.swift
+++ b/Tests/MasseTests/MiniMarkdownTests.swift
@@ -118,6 +118,26 @@ final class MinimarkdownTests: XCTestCase {
         XCTAssertEqual(MiniMarkdownParser().parseHTML("ab\n\ncd\n\nef"),
             "<p>ab</p><p>cd</p><p>ef</p>")
     }
+    
+    func testEm1() {
+        let content = "this *hello* is brief"
+        XCTAssertEqual("<p>this <strong>hello</strong> is brief</p>", MiniMarkdownParser().parseHTML(content))
+    }
+    
+    func testEm2() {
+        let content = "this *hello* is *brief*"
+        XCTAssertEqual("<p>this <strong>hello</strong> is <strong>brief</strong></p>", MiniMarkdownParser().parseHTML(content))
+    }
+    
+    func testEm3() {
+        let content = "this * hello * is brief"
+        XCTAssertEqual("<p>this * hello * is brief</p>", MiniMarkdownParser().parseHTML(content))
+    }
+    
+    func testEm4() {
+        let content = "this *hello *is brief"
+        XCTAssertEqual("<p>this *hello *is brief</p>", MiniMarkdownParser().parseHTML(content))
+    }
 
     func testMarkdown() {
         let content = """
@@ -128,11 +148,11 @@ paragraph
 paragraph [paragraph](paragraph)
 paragraph
 
-## Second headline [^1]
+## Second *headline* [^1]
 
 - List 1
 - List 2
-- list 3
+- *list* 3
 
 ### Third headline
 
@@ -140,13 +160,13 @@ longer pargraph
 
 [^1] Footnote 1. Done.
 """
-        let expected = "<h1>First Headline</h1><p><img src='paragraph' alt='paragraph' />, paragrahp<br/>paragraph</p><p>paragraph <a href='paragraph'>paragraph</a><br/>paragraph</p><h2>Second headline <a href='#1'>[1]</a></h2><ul><li>List 1</li><li>List 2</li><li>list 3</li></ul><h3>Third headline</h3><p>longer pargraph</p><div><strong><a name='1'>[1]:</a></strong> Footnote 1. Done.</div>"
+        let expected = "<h1>First Headline</h1><p><img src='paragraph' alt='paragraph' />, paragrahp<br/>paragraph</p><p>paragraph <a href='paragraph'>paragraph</a><br/>paragraph</p><h2>Second <strong>headline</strong> <a href='#1'>[1]</a></h2><ul><li>List 1</li><li>List 2</li><li><strong>list</strong> 3</li></ul><h3>Third headline</h3><p>longer pargraph</p><div><strong><a name='1'>[1]:</a></strong> Footnote 1. Done.</div>"
         XCTAssertEqual(expected, MiniMarkdownParser().parseHTML(content))
     }
 
     private func convertHTMLRefs(_ content: String) -> String {
         let html = MiniMarkdownParser.Element.paragraph(contents: [])
-            .convertRefs(content[content.startIndex..<content.endIndex])
+            .convertRefs(String(content[content.startIndex..<content.endIndex]))
         return html
     }
 
@@ -174,5 +194,6 @@ longer pargraph
         ("testMarkdownList", testMarkdownList),
         ("testMarkdownParagraphs1", testMarkdownParagraphs1),
         ("testMarkdownParagraphs2", testMarkdownParagraphs2),
+        ("testEm1", testEm1),
         ]
 }

--- a/Tests/MasseTests/MiniMarkdownTests.swift
+++ b/Tests/MasseTests/MiniMarkdownTests.swift
@@ -1,0 +1,177 @@
+import XCTest
+@testable import Masse
+
+import Foundation
+
+final class MinimarkdownTests: XCTestCase {
+    func testHTMLElements() {
+        XCTAssertEqual(MiniMarkdownParser.Element.footnote(identifier: "a", contents: "Hello").html, "<div><strong><a name='a'>[a]:</a></strong> Hello</div>")
+        XCTAssertEqual(MiniMarkdownParser.Element.headline(level: 2, title: "Hello").html, "<h2>Hello</h2>")
+        XCTAssertEqual(MiniMarkdownParser.Element.list(entries: [(index: 1, contents: "Hello"),
+                                                     (index: 2, contents: "World")]).html,
+                       "<ul><li>Hello</li><li>World</li></ul>")
+        XCTAssertEqual(MiniMarkdownParser.Element.paragraph(contents: ["hello", "world", "joe"]).html, "<p>hello<br/>world<br/>joe</p>")
+    }
+
+    func testHTMLRefs1() {
+        XCTAssert(
+            convertHTMLRefs("this is a [url](http://heise.de)")
+                ==
+            "this is a <a href='http://heise.de'>url</a>"
+        )
+    }
+
+    func testHTMLRefs2() {
+        XCTAssert(
+            convertHTMLRefs("this is a [url](http://heise.de) with more")
+                ==
+            "this is a <a href='http://heise.de'>url</a> with more"
+        )
+    }
+
+    func testHTMLRefs3() {
+        XCTAssert(
+            convertHTMLRefs("oh [these](a) are [two](b) [urls](c)")
+                ==
+            "oh <a href='a'>these</a> are <a href='b'>two</a> <a href='c'>urls</a>"
+        )
+    }
+
+    func testHTMLRefs4() {
+        XCTAssert(
+            convertHTMLRefs("pure content")
+                ==
+            "pure content"
+        )
+    }
+
+    func testHTMLRefs5() {
+        XCTAssert(
+            convertHTMLRefs("[hui](test)")
+                ==
+            "<a href='test'>hui</a>"
+        )
+    }
+
+    func testHTMLRefs6() {
+        XCTAssert(
+            convertHTMLRefs("[hui](test)[huihui](testtest)")
+                ==
+            "<a href='test'>hui</a><a href='testtest'>huihui</a>"
+        )
+    }
+
+    func testHTMLRefs7() {
+        XCTAssert(
+            convertHTMLRefs("![hello](/img.jpg)")
+                ==
+            "<img src='/img.jpg' alt='hello' />"
+        )
+    }
+
+    func testHTMLRefs8() {
+        XCTAssert(
+            convertHTMLRefs("an ![hello](/img.jpg) image")
+                ==
+            "an <img src='/img.jpg' alt='hello' /> image"
+        )
+    }
+
+    func testHTMLRefs9() {
+        XCTAssert(
+            convertHTMLRefs("the [^on] is on")
+                ==
+            "the <a href='#on'>[on]</a> is on"
+        )
+    }
+
+    func testSplitWithBreaks() {
+        let content = "a\n\nb\nc\nd\n\ne"
+        let parsed = splitWithBreaks(lines: content)
+        XCTAssert(parsed == ["a", "", "b", "c", "d", "", "e"])
+    }
+
+    func testSplitWithBreaksNoBreaks() {
+        let content = "# test"
+        let parsed = splitWithBreaks(lines: content)
+        XCTAssert(parsed == ["# test"])
+    }
+
+    func testMarkdownTitle1() {
+        XCTAssert(convertMarkdown("# test") == "<h1>test</h1>")
+    }
+
+    func testMarkdownTitle2() {
+        XCTAssert(convertMarkdown("## test") == "<h2>test</h2>")
+    }
+
+    func testMarkdownList() {
+        XCTAssert(convertMarkdown("- a\n- b") == "<ul><li>a</li><li>b</li></ul>")
+    }
+
+    func testMarkdownParagraphs1() {
+        XCTAssert(MiniMarkdownParser().parseHTML("ab\ncd\n\nef") ==
+        "<p>ab<br/>cd</p><p>ef</p>")
+    }
+
+    func testMarkdownParagraphs2() {
+        XCTAssert(MiniMarkdownParser().parseHTML("ab\n\ncd\n\nef") ==
+            "<p>ab</p><p>cd</p><p>ef</p>")
+    }
+
+    func testMarkdown() {
+        let content = """
+# First Headline
+![paragraph](paragraph), paragrahp
+paragraph
+
+paragraph [paragraph](paragraph)
+paragraph
+
+## Second headline [^1]
+
+- List 1
+- List 2
+- list 3
+
+### Third headline
+
+longer pargraph
+
+[^1] Footnote 1. Done.
+"""
+        print(MiniMarkdownParser().parseHTML(content))
+    }
+
+    private func convertHTMLRefs(_ content: String) -> String {
+        let html = MiniMarkdownParser.Element.paragraph(contents: [])
+            .convertRefs(content[content.startIndex..<content.endIndex])
+        return html
+    }
+
+    private func convertMarkdown(_ content: String) -> String {
+        let p = MiniMarkdownParser()
+        let elements = p.parse(content)
+        return elements[0].html
+    }
+
+    static var allTests = [
+        ("testHTMLElements", testHTMLElements),
+        ("testHTMLRefs1", testHTMLRefs1),
+        ("testHTMLRefs2", testHTMLRefs2),
+        ("testHTMLRefs3", testHTMLRefs3),
+        ("testHTMLRefs4", testHTMLRefs4),
+        ("testHTMLRefs5", testHTMLRefs5),
+        ("testHTMLRefs6", testHTMLRefs6),
+        ("testHTMLRefs7", testHTMLRefs7),
+        ("testHTMLRefs8", testHTMLRefs8),
+        ("testHTMLRefs9", testHTMLRefs9),
+        ("testSplitWithBreaks", testSplitWithBreaks),
+        ("testSplitWithBreaksNoBreaks", testSplitWithBreaksNoBreaks),
+        ("testMarkdownTitle1", testMarkdownTitle1),
+        ("testMarkdownTitle2", testMarkdownTitle2),
+        ("testMarkdownList", testMarkdownList),
+        ("testMarkdownParagraphs1", testMarkdownParagraphs1),
+        ("testMarkdownParagraphs2", testMarkdownParagraphs2),
+        ]
+}

--- a/Tests/MasseTests/MiniMarkdownTests.swift
+++ b/Tests/MasseTests/MiniMarkdownTests.swift
@@ -14,108 +14,108 @@ final class MinimarkdownTests: XCTestCase {
     }
 
     func testHTMLRefs1() {
-        XCTAssert(
+        XCTAssertEqual(
             convertHTMLRefs("this is a [url](http://heise.de)")
-                ==
+            ,
             "this is a <a href='http://heise.de'>url</a>"
         )
     }
 
     func testHTMLRefs2() {
-        XCTAssert(
+        XCTAssertEqual(
             convertHTMLRefs("this is a [url](http://heise.de) with more")
-                ==
+            ,
             "this is a <a href='http://heise.de'>url</a> with more"
         )
     }
 
     func testHTMLRefs3() {
-        XCTAssert(
+        XCTAssertEqual(
             convertHTMLRefs("oh [these](a) are [two](b) [urls](c)")
-                ==
+            ,
             "oh <a href='a'>these</a> are <a href='b'>two</a> <a href='c'>urls</a>"
         )
     }
 
     func testHTMLRefs4() {
-        XCTAssert(
+        XCTAssertEqual(
             convertHTMLRefs("pure content")
-                ==
+            ,
             "pure content"
         )
     }
 
     func testHTMLRefs5() {
-        XCTAssert(
+        XCTAssertEqual(
             convertHTMLRefs("[hui](test)")
-                ==
+            ,
             "<a href='test'>hui</a>"
         )
     }
 
     func testHTMLRefs6() {
-        XCTAssert(
+        XCTAssertEqual(
             convertHTMLRefs("[hui](test)[huihui](testtest)")
-                ==
+            ,
             "<a href='test'>hui</a><a href='testtest'>huihui</a>"
         )
     }
 
     func testHTMLRefs7() {
-        XCTAssert(
+        XCTAssertEqual(
             convertHTMLRefs("![hello](/img.jpg)")
-                ==
+            ,
             "<img src='/img.jpg' alt='hello' />"
         )
     }
 
     func testHTMLRefs8() {
-        XCTAssert(
+        XCTAssertEqual(
             convertHTMLRefs("an ![hello](/img.jpg) image")
-                ==
+             ,
             "an <img src='/img.jpg' alt='hello' /> image"
         )
     }
 
     func testHTMLRefs9() {
-        XCTAssert(
+        XCTAssertEqual(
             convertHTMLRefs("the [^on] is on")
-                ==
+            ,
             "the <a href='#on'>[on]</a> is on"
         )
     }
 
     func testSplitWithBreaks() {
         let content = "a\n\nb\nc\nd\n\ne"
-        let parsed = splitWithBreaks(lines: content)
-        XCTAssert(parsed == ["a", "", "b", "c", "d", "", "e"])
+        let parsed = content.splitWithBreaks()
+        XCTAssertEqual(parsed, ["a", "", "b", "c", "d", "", "e"])
     }
 
     func testSplitWithBreaksNoBreaks() {
         let content = "# test"
-        let parsed = splitWithBreaks(lines: content)
-        XCTAssert(parsed == ["# test"])
+        let parsed = content.splitWithBreaks()
+        XCTAssertEqual(parsed, ["# test"])
     }
 
     func testMarkdownTitle1() {
-        XCTAssert(convertMarkdown("# test") == "<h1>test</h1>")
+        XCTAssertEqual(convertMarkdown("# test"), "<h1>test</h1>")
     }
 
     func testMarkdownTitle2() {
-        XCTAssert(convertMarkdown("## test") == "<h2>test</h2>")
+        XCTAssertEqual(convertMarkdown("## test"), "<h2>test</h2>")
     }
 
     func testMarkdownList() {
-        XCTAssert(convertMarkdown("- a\n- b") == "<ul><li>a</li><li>b</li></ul>")
+        XCTAssertEqual(convertMarkdown("- a\n- b"), "<ul><li>a</li><li>b</li></ul>")
     }
 
     func testMarkdownParagraphs1() {
-        XCTAssert(MiniMarkdownParser().parseHTML("ab\ncd\n\nef") ==
+        XCTAssertEqual(MiniMarkdownParser().parseHTML("ab\ncd\n\nef"),
         "<p>ab<br/>cd</p><p>ef</p>")
     }
 
     func testMarkdownParagraphs2() {
-        XCTAssert(MiniMarkdownParser().parseHTML("ab\n\ncd\n\nef") ==
+        XCTAssertEqual(MiniMarkdownParser().parseHTML("ab\n\ncd\n\nef"),
             "<p>ab</p><p>cd</p><p>ef</p>")
     }
 
@@ -140,7 +140,8 @@ longer pargraph
 
 [^1] Footnote 1. Done.
 """
-        print(MiniMarkdownParser().parseHTML(content))
+        let expected = "<h1>First Headline</h1><p><img src='paragraph' alt='paragraph' />, paragrahp<br/>paragraph</p><p>paragraph <a href='paragraph'>paragraph</a><br/>paragraph</p><h2>Second headline <a href='#1'>[1]</a></h2><ul><li>List 1</li><li>List 2</li><li>list 3</li></ul><h3>Third headline</h3><p>longer pargraph</p><div><strong><a name='1'>[1]:</a></strong> Footnote 1. Done.</div>"
+        XCTAssertEqual(expected, MiniMarkdownParser().parseHTML(content))
     }
 
     private func convertHTMLRefs(_ content: String) -> String {

--- a/Tests/MasseTests/TemplateTests.swift
+++ b/Tests/MasseTests/TemplateTests.swift
@@ -77,10 +77,14 @@ goobye
  - author: Bas Broek / Benedikt Terhechte
  - description: This is a long description with a really long description and another long description.
  ---
- <h1>These are the show notes</h1>
- <p> with some text
- and some more text</p>
- <strong>the end</strong>
+ # These are the show notes
+ - name: url
+ - name: url
+
+ - name: url
+
+ # New notes
+ - name: url
  """
         let parser = ConfigEntryParser(contents: entry, keys: Keys.PodcastEntry.allCases.map { $0.rawValue }, overflowKey: Keys.PodcastEntry.notes.rawValue)
         let dict = parser.retrieve()
@@ -90,10 +94,26 @@ goobye
         XCTAssertEqual(dict["duration"], "00:33:22")
         XCTAssertEqual(dict["length"], "404")
         XCTAssertEqual(dict["notes"], """
-<h1>These are the show notes</h1>
-<p> with some text
-and some more text</p>
-<strong>the end</strong>
+<div>
+  <p>
+    <h3>These are the show notes</h3>
+    <ul>
+      <li><a href="url">name</a></li>
+      <li><a href="url">name</a></li>
+    </ul>
+
+    <ul>
+      <li><a href="url">name</a></li>
+    </ul>
+  </p>
+
+  <p>
+    <h3>New notes</h3>
+    <ul>
+      <li><a href="url">name</a></li>
+    </ul>
+  </p>
+</div>
 
 """)
     }

--- a/Tests/MasseTests/TemplateTests.swift
+++ b/Tests/MasseTests/TemplateTests.swift
@@ -55,7 +55,6 @@ goobye
  </html>
  """
         let parser = TemplateVariablesParser(contents: template, sections: [:], variables: variables, context: context)
-        print(parser.retrieve())
         XCTAssertEqual(parser.retrieve(), """
 <html>
 <b>1 of hans with age 55 in 1</b>

--- a/Tests/MasseTests/TemplateTests.swift
+++ b/Tests/MasseTests/TemplateTests.swift
@@ -93,29 +93,7 @@ goobye
         XCTAssertEqual(dict["file"], "something.mp3")
         XCTAssertEqual(dict["duration"], "00:33:22")
         XCTAssertEqual(dict["length"], "404")
-        XCTAssertEqual(dict["notes"], """
-<div>
-  <p>
-    <h3>These are the show notes</h3>
-    <ul>
-      <li><a href="url">name</a></li>
-      <li><a href="url">name</a></li>
-    </ul>
-
-    <ul>
-      <li><a href="url">name</a></li>
-    </ul>
-  </p>
-
-  <p>
-    <h3>New notes</h3>
-    <ul>
-      <li><a href="url">name</a></li>
-    </ul>
-  </p>
-</div>
-
-""")
+        XCTAssertEqual(dict["notes"], "<h1>These are the show notes</h1><ul><li>name: url</li><li>name: url</li></ul><ul><li>name: url</li></ul><h1>New notes</h1><ul><li>name: url</li></ul>")
     }
     
     

--- a/Tests/MasseTests/XCTestManifests.swift
+++ b/Tests/MasseTests/XCTestManifests.swift
@@ -4,6 +4,8 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(MasseTests.allTests),
+        testCase(TemplateTests.allTests),
+        testCase(MiniMarkdownTests.allTests)
     ]
 }
 #endif

--- a/build.swift
+++ b/build.swift
@@ -27,7 +27,7 @@ do {
   for fileURL in files {
       print(try String(contentsOf: fileURL), terminator: "\n", to: &output)
   }
-  output.append("\n\(runCommand)")
+  output.append("\n\(runCommand)\n")
   try output.write(to: URL(fileURLWithPath: distTarget), atomically: true, encoding: .utf8)
 } catch let error {
   print("Could not build \(distTarget)")


### PR DESCRIPTION
This adds a format for show notes that will parse them to HTML.

The following format is expected:

```
# title
- description1: url1
- description2: url2

- description3: url3

# anotherTitle
- description4: url4
```

This will generate:

```html
<div>
  <p>
  <h3>title</h3>
  <ul>
    <li><a href="url1">description1</a></li>
    <li><a href="url2">description2</a></li>
  </ul>
  <ul>
    <li><a href="url3">description3</a></li>
  </ul>
  </p>
  <p>
  <h3>anotherTitle</h3>
  <ul>
    <li><a href="url4">description4</a></li>
  </ul>
  </p>
<div>
```